### PR TITLE
ci(fix): go module caching

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -37,18 +37,6 @@ jobs:
       - name: Check Go Version
         run: go version
 
-      - name: Cache Go Modules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-go-modules
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.OS }}-build-${{ env.cache-name }}-
-            ${{ runner.OS }}-build-
-            ${{ runner.OS }}-
-
       - name: Sync
         working-directory: .
         run: go mod download
@@ -81,18 +69,6 @@ jobs:
 
       - name: Check Go Version
         run: go version
-
-      - name: Cache Go Modules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-go-modules
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.OS }}-build-${{ env.cache-name }}-
-            ${{ runner.OS }}-build-
-            ${{ runner.OS }}-
 
       - name: Lint
         uses: golangci/golangci-lint-action@v3
@@ -130,18 +106,6 @@ jobs:
 
       - name: Check Go Version
         run: go version
-
-      - name: Cache Go Modules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-go-modules
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.OS }}-build-${{ env.cache-name }}-
-            ${{ runner.OS }}-build-
-            ${{ runner.OS }}-
 
       - name: Test
         working-directory: .

--- a/.github/workflows/tests_codecov.yml
+++ b/.github/workflows/tests_codecov.yml
@@ -29,18 +29,6 @@ jobs:
       - name: Check Go Version
         run: go version
 
-      - name: Cache Go Modules
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-go-modules
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.OS }}-build-${{ env.cache-name }}-
-            ${{ runner.OS }}-build-
-            ${{ runner.OS }}-
-
       - name: Test
         working-directory: .
         run: go test -race -coverprofile=coverage.txt -covermode=atomic -v ./...


### PR DESCRIPTION
The actions/setup-go GitHub workflow action (v4) already caches go modules by default:

- https://github.com/marketplace/actions/setup-go-environment
- https://github.blog/changelog/2023-03-24-github-actions-the-setup-go-action-now-enables-caching-by-default/