### PR TITLE
refactor: improve request key perf & optimise store impl

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,11 +3,9 @@
 run:
   timeout: 5m
 
-
 linters:
   disable-all: true
   enable:
-
     # Check for pass []any as any in variadic func(...any).
     - asasalint
 
@@ -234,9 +232,7 @@ linters:
     # reassign, testpackage
     #
 
-
 linters-settings:
-
   cyclop:
     max-complexity: 20
     package-average: 0.0
@@ -408,7 +404,7 @@ linters-settings:
             allowFloats: "0.0"
             ignoreFuncs: "fmt\\.Errorf"
       - name: line-length-limit
-        arguments: [ 120 ]
+        arguments: [120]
 
   staticcheck:
     checks: ["*"]
@@ -427,7 +423,7 @@ linters-settings:
     check-exported: false
 
   varnamelen:
-    max-distance: 5
+    max-distance: 7
     min-name-length: 3
     check-receiver: false
     check-return: false
@@ -443,9 +439,15 @@ linters-settings:
       - to
       - os
       - wg
+      - i
     ignore-decls:
       - wg sync.WaitGroup
       - t T
+  nlreturn:
+    # Size of the block (including return statement that is still "OK")
+    # so no return split required.
+    # Default: 1
+    block-size: 3
 
   wrapcheck:
     ignoreSigs:
@@ -472,7 +474,6 @@ linters-settings:
     force-err-cuddling: true
     force-short-decl-cuddling: true
     strict-append: true
-
 
 issues:
   exclude-files:

--- a/client.go
+++ b/client.go
@@ -49,8 +49,8 @@ type Client struct {
 	waitGroup sync.WaitGroup
 
 	buffers     bufPool
-	requests    requests
-	liveQueries liveQueries
+	requests    *requests
+	liveQueries *liveQueries
 }
 
 // Config is the configuration for the client.
@@ -100,6 +100,9 @@ func NewClient(ctx context.Context, conf Config, opts ...Option) (*Client, error
 
 	client.marshal = enc.Marshal
 	client.unmarshal = dec.Unmarshal
+
+	client.requests = NewRequests()
+	client.liveQueries = NewLiveQueries()
 
 	client.connCtx, client.connCancel = context.WithCancel(ctx)
 

--- a/client.go
+++ b/client.go
@@ -101,8 +101,8 @@ func NewClient(ctx context.Context, conf Config, opts ...Option) (*Client, error
 	client.marshal = enc.Marshal
 	client.unmarshal = dec.Unmarshal
 
-	client.requests = NewRequests()
-	client.liveQueries = NewLiveQueries()
+	client.requests = newRequests()
+	client.liveQueries = newLiveQueries()
 
 	client.connCtx, client.connCancel = context.WithCancel(ctx)
 

--- a/methods.go
+++ b/methods.go
@@ -601,7 +601,7 @@ func (c *Client) send(ctx context.Context, req request) ([]byte, error) {
 	defer c.checkWebsocketConn(err)
 
 	reqID, resCh := c.requests.prepare()
-	defer c.requests.cleanup(reqID)
+	defer c.requests.del(reqID)
 
 	req.ID = reqID
 

--- a/response.go
+++ b/response.go
@@ -65,7 +65,7 @@ func (c *Client) read(ctx context.Context) (*bytes.Buffer, error) {
 		return nil, fmt.Errorf("%w, got %v", ErrExpectedTextMessage, msgType)
 	}
 
-	buf := c.buffers.Get()
+	buf := c.buffers.get()
 
 	if _, err = buf.ReadFrom(reader); err != nil {
 		return nil, fmt.Errorf("failed to read message: %w", err)
@@ -86,11 +86,11 @@ func (c *Client) handleMessage(buf *bytes.Buffer) {
 			"error", err,
 		)
 
-		c.buffers.Put(buf) // Release as soon as possible
+		c.buffers.put(buf) // Release as soon as possible
 
 		return
 	}
-	c.buffers.Put(buf) // Release as soon as possible
+	c.buffers.put(buf) // Release as soon as possible
 
 	if res.ID == "" && res.Error != nil {
 		c.logger.ErrorContext(c.connCtx, "Received error message.",

--- a/stores.go
+++ b/stores.go
@@ -12,21 +12,21 @@ import (
 //
 
 type bufPool struct {
-	sync.Pool
+	syncPool sync.Pool
 }
 
 // Get returns a buffer from the pool or
 // creates a new one if the pool is empty.
 func (p *bufPool) Get() *bytes.Buffer {
-	buf := p.Pool.Get()
+	buf := p.syncPool.Get()
 
 	if buf == nil {
-		return &bytes.Buffer{}
+		return bytes.NewBuffer(make([]byte, 0, bytes.MinRead*2))
 	}
 
 	bytesBuf, ok := buf.(*bytes.Buffer)
 	if !ok {
-		return &bytes.Buffer{}
+		return bytes.NewBuffer(make([]byte, 0, bytes.MinRead*2))
 	}
 
 	return bytesBuf
@@ -36,7 +36,7 @@ func (p *bufPool) Get() *bytes.Buffer {
 func (p *bufPool) Put(buf *bytes.Buffer) {
 	buf.Reset()
 
-	p.Pool.Put(buf)
+	p.syncPool.Put(buf)
 }
 
 //

--- a/stores.go
+++ b/stores.go
@@ -2,8 +2,10 @@ package sdbc
 
 import (
 	"bytes"
-	"crypto/rand"
-	"fmt"
+	cryptorand "crypto/rand"
+	"encoding/base64"
+	"encoding/binary"
+	"math/rand/v2"
 	"sync"
 )
 
@@ -43,31 +45,39 @@ func (p *bufPool) Put(buf *bytes.Buffer) {
 // -- REQUESTS
 //
 
+func NewRequests() *requests {
+	return &requests{
+		store: map[string]chan *output{},
+	}
+}
+
 type output struct {
 	data []byte
 	err  error
 }
 
 type requests struct {
-	store sync.Map
+	mut   sync.RWMutex
+	store map[string]chan *output
 }
 
 func (r *requests) prepare() (string, <-chan *output) {
-	key := newRequestKey() // TODO: generate multiple keys beforehand and reuse by using sync.Pool?
-	ch := make(chan *output)
+	key := newRequestKey()
+	outChan := make(chan *output)
 
-	r.store.Store(key, ch)
+	r.mut.Lock()
+	defer r.mut.Unlock()
 
-	return key, ch
+	r.store[key] = outChan
+
+	return key, outChan
 }
 
 func (r *requests) get(key string) (chan<- *output, bool) {
-	val, ok := r.store.Load(key)
-	if !ok {
-		return nil, false
-	}
+	r.mut.RLock()
+	defer r.mut.RUnlock()
 
-	outChan, ok := val.(chan *output)
+	outChan, ok := r.store[key]
 	if !ok {
 		return nil, false
 	}
@@ -75,87 +85,88 @@ func (r *requests) get(key string) (chan<- *output, bool) {
 	return outChan, true
 }
 
-func (r *requests) cleanup(key string) {
-	if ch, ok := r.store.LoadAndDelete(key); ok {
-		if outChan, ok := ch.(chan *output); ok {
-			close(outChan)
-		}
+func (r *requests) del(key string) {
+	r.mut.Lock()
+	defer r.mut.Unlock()
+
+	if outChan, ok := r.store[key]; ok {
+		close(outChan)
+		delete(r.store, key)
 	}
 }
 
 func (r *requests) reset() {
-	r.store.Range(func(key, ch any) bool {
-		if outChan, ok := ch.(chan *output); ok {
-			close(outChan)
-		}
+	r.mut.Lock()
+	defer r.mut.Unlock()
 
-		r.store.Delete(key)
-
-		return true
-	})
+	for _, outChan := range r.store {
+		close(outChan)
+	}
+	r.store = map[string]chan *output{}
 }
 
 func (r *requests) len() int {
-	count := 0
+	r.mut.RLock()
+	defer r.mut.RUnlock()
 
-	r.store.Range(func(key, ch any) bool {
-		count++
-
-		return true
-	})
-
-	return count
+	return len(r.store)
 }
 
 //
 // -- LIVE QUERIES
 //
 
+func NewLiveQueries() *liveQueries {
+	return &liveQueries{
+		store: map[string]chan []byte{},
+	}
+}
+
 type liveQueries struct {
-	store sync.Map
+	mut   sync.RWMutex
+	store map[string]chan []byte
 }
 
 func (l *liveQueries) get(key string, create bool) (chan []byte, bool) {
-	val, ok := l.store.Load(key)
+	l.mut.RLock()
+	liveChan, ok := l.store[key]
+	l.mut.RUnlock()
 
 	if !ok && !create {
 		return nil, false
 	}
 
 	if !ok {
-		ch := make(chan []byte)
+		newLiveChan := make(chan []byte)
 
-		l.store.Store(key, ch)
+		l.mut.Lock()
+		l.store[key] = newLiveChan
+		l.mut.Unlock()
 
-		return ch, true
-	}
-
-	liveChan, ok := val.(chan []byte)
-	if !ok {
-		return nil, false
+		return newLiveChan, true
 	}
 
 	return liveChan, true
 }
 
 func (l *liveQueries) del(key string) {
-	if ch, ok := l.store.LoadAndDelete(key); ok {
-		if liveChan, ok := ch.(chan []byte); ok {
-			close(liveChan)
-		}
+	l.mut.Lock()
+	defer l.mut.Unlock()
+
+	if liveChan, ok := l.store[key]; ok {
+		close(liveChan)
+		delete(l.store, key)
 	}
 }
 
 func (l *liveQueries) reset() {
-	l.store.Range(func(key, ch any) bool {
-		if liveChan, ok := ch.(chan []byte); ok {
-			close(liveChan)
-		}
+	l.mut.Lock()
+	defer l.mut.Unlock()
 
-		l.store.Delete(key)
-
-		return true
-	})
+	for _, outChan := range l.store {
+		close(outChan)
+	}
+	l.store = map[string]chan []byte{}
 }
 
 //
@@ -163,15 +174,61 @@ func (l *liveQueries) reset() {
 //
 
 const (
-	requestKeyLength = 16
+	RequestKeyLength = 16
+	BytesInUint64    = 8
 )
 
-func newRequestKey() string {
-	key := make([]byte, requestKeyLength)
+var randBytes = NewRandBytes()
 
-	if _, err := rand.Read(key); err != nil {
-		return "" // TODO: error?
+func NewRandBytes() *RandBytes {
+	randomBytes := make([]byte, BytesInUint64*2)
+
+	if _, err := cryptorand.Read(randomBytes); err != nil {
+		panic("unreachable")
 	}
 
-	return fmt.Sprintf("%X-%X-%X-%X-%X", key[0:4], key[4:6], key[6:8], key[8:10], key[10:])
+	return &RandBytes{
+		//nolint:gosec // no security required
+		rng: rand.New(rand.NewPCG(
+			binary.LittleEndian.Uint64(randomBytes[:8]),
+			binary.LittleEndian.Uint64(randomBytes[8:]),
+		)),
+		bytesForUint64: make([]byte, BytesInUint64),
+	}
+}
+
+type RandBytes struct {
+	mut            sync.Mutex
+	rng            *rand.Rand
+	bytesForUint64 []byte
+}
+
+// Read fills bytes with random bytes. It never returns an error, and always fills bytes entirely.
+func (rb *RandBytes) Read(bytes []byte) {
+	numBytes := len(bytes)
+	numUint64s := numBytes / BytesInUint64
+	remainingBytes := numBytes % BytesInUint64
+
+	rb.mut.Lock()
+	defer rb.mut.Unlock()
+
+	// Fill the slice with 8-byte chunks
+	for i := range numUint64s {
+		from := i * BytesInUint64
+		to := (i + 1) * BytesInUint64
+		binary.LittleEndian.PutUint64(bytes[from:to], rb.rng.Uint64())
+	}
+
+	// Handle remaining bytes (if any)
+	if remainingBytes > 0 {
+		binary.LittleEndian.PutUint64(rb.bytesForUint64[0:], rb.rng.Uint64())
+		copy(bytes[numUint64s*BytesInUint64:], rb.bytesForUint64[:remainingBytes])
+	}
+}
+
+func newRequestKey() string {
+	key := make([]byte, RequestKeyLength)
+	randBytes.Read(key)
+
+	return base64.RawURLEncoding.EncodeToString(key)
 }

--- a/stores.go
+++ b/stores.go
@@ -3,9 +3,7 @@ package sdbc
 import (
 	"bytes"
 	cryptorand "crypto/rand"
-	"encoding/base64"
 	"encoding/binary"
-	"fmt"
 	"math/rand/v2"
 	"sync"
 )
@@ -74,7 +72,7 @@ type requests struct {
 }
 
 func (r *requests) prepare() (string, <-chan *output) {
-	key := newRequestKey4()
+	key := newRequestKey()
 	outChan := make(chan *output)
 
 	r.mut.Lock()
@@ -247,26 +245,9 @@ func (rb *RandBytes) Base62Str(length int) string {
 	return str
 }
 
-// Uniform distribution, but slower and variable key length (<= RequestKeyLength).
-func newRequestKey5() string {
-	key := make([]byte, RequestKeyLength)
-	randBytes.Read(key)
-
-	offs := 0
-	for i, b := range key {
-		if b > unbiasedMaxVal {
-			offs--
-			continue
-		}
-		key[i+offs] = charset[int(b)%charsetLen]
-	}
-
-	return string(key[:len(key)+offs])
-}
-
 // Fastest, but random distribution is not uniform.
 // Not security-critical in this case, so acceptable.
-func newRequestKey4() string {
+func newRequestKey() string {
 	key := make([]byte, RequestKeyLength)
 	randBytes.Read(key)
 
@@ -275,28 +256,4 @@ func newRequestKey4() string {
 	}
 
 	return string(key)
-}
-
-// Similar to official driver.
-func newRequestKey2() string {
-	return randBytes.Base62Str(RequestKeyLength)
-}
-
-// Using simpler rng, and base64.
-func newRequestKey1() string {
-	key := make([]byte, RequestKeyLength)
-	randBytes.Read(key)
-
-	return base64.RawURLEncoding.EncodeToString(key)
-}
-
-// Original uuid-like implementation.
-func newRequestKey0() string {
-	key := make([]byte, RequestKeyLength)
-
-	if _, err := cryptorand.Read(key); err != nil {
-		return "" // TODO: error?
-	}
-
-	return fmt.Sprintf("%X-%X-%X-%X-%X", key[0:4], key[4:6], key[6:8], key[8:10], key[10:])
 }

--- a/stores_bench_test.go
+++ b/stores_bench_test.go
@@ -37,10 +37,10 @@ func BenchmarkNewRequestKey5(b *testing.B) {
 	}
 }
 
-// Uniform distribution, but slower and variable key length (<= RequestKeyLength).
+// Uniform distribution, but slower and variable key length (<= requestKeyLength).
 func newRequestKey5() string {
-	key := make([]byte, RequestKeyLength)
-	randBytes.Read(key)
+	key := make([]byte, requestKeyLength)
+	defaultRandBytes.read(key)
 
 	offs := 0
 	for i, b := range key {
@@ -60,20 +60,20 @@ func newRequestKey5() string {
 
 // Similar to official driver.
 func newRequestKey2() string {
-	return randBytes.Base62Str(RequestKeyLength)
+	return defaultRandBytes.base62Str(requestKeyLength)
 }
 
 // Using simpler rng, and base64.
 func newRequestKey1() string {
-	key := make([]byte, RequestKeyLength)
-	randBytes.Read(key)
+	key := make([]byte, requestKeyLength)
+	defaultRandBytes.read(key)
 
 	return base64.RawURLEncoding.EncodeToString(key)
 }
 
 // Original uuid-like implementation.
 func newRequestKey0() string {
-	key := make([]byte, RequestKeyLength)
+	key := make([]byte, requestKeyLength)
 
 	if _, err := cryptorand.Read(key); err != nil {
 		return "" // TODO: error?

--- a/stores_bench_test.go
+++ b/stores_bench_test.go
@@ -1,6 +1,11 @@
 package sdbc
 
-import "testing"
+import (
+	cryptorand "crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"testing"
+)
 
 func BenchmarkNewRequestKey0(b *testing.B) {
 	for i := 0; i < b.N; i++ {
@@ -22,7 +27,7 @@ func BenchmarkNewRequestKey2(b *testing.B) {
 
 func BenchmarkNewRequestKey4(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		newRequestKey4()
+		newRequestKey()
 	}
 }
 
@@ -30,4 +35,49 @@ func BenchmarkNewRequestKey5(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		newRequestKey5()
 	}
+}
+
+// Uniform distribution, but slower and variable key length (<= RequestKeyLength).
+func newRequestKey5() string {
+	key := make([]byte, RequestKeyLength)
+	randBytes.Read(key)
+
+	offs := 0
+	for i, b := range key {
+		if b > unbiasedMaxVal {
+			offs--
+			continue
+		}
+		key[i+offs] = charset[int(b)%charsetLen]
+	}
+
+	return string(key[:len(key)+offs])
+}
+
+// newRequestKey4 is newRequestKey from stores.go
+
+// newRequestKey3 was a failed attempt
+
+// Similar to official driver.
+func newRequestKey2() string {
+	return randBytes.Base62Str(RequestKeyLength)
+}
+
+// Using simpler rng, and base64.
+func newRequestKey1() string {
+	key := make([]byte, RequestKeyLength)
+	randBytes.Read(key)
+
+	return base64.RawURLEncoding.EncodeToString(key)
+}
+
+// Original uuid-like implementation.
+func newRequestKey0() string {
+	key := make([]byte, RequestKeyLength)
+
+	if _, err := cryptorand.Read(key); err != nil {
+		return "" // TODO: error?
+	}
+
+	return fmt.Sprintf("%X-%X-%X-%X-%X", key[0:4], key[4:6], key[6:8], key[8:10], key[10:])
 }

--- a/stores_bench_test.go
+++ b/stores_bench_test.go
@@ -1,0 +1,33 @@
+package sdbc
+
+import "testing"
+
+func BenchmarkNewRequestKey0(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		newRequestKey0()
+	}
+}
+
+func BenchmarkNewRequestKey1(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		newRequestKey1()
+	}
+}
+
+func BenchmarkNewRequestKey2(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		newRequestKey2()
+	}
+}
+
+func BenchmarkNewRequestKey4(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		newRequestKey4()
+	}
+}
+
+func BenchmarkNewRequestKey5(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		newRequestKey5()
+	}
+}

--- a/stores_test.go
+++ b/stores_test.go
@@ -2,6 +2,7 @@ package sdbc
 
 import (
 	"bytes"
+	"math/rand/v2"
 	"testing"
 	"time"
 
@@ -24,21 +25,9 @@ func TestStoresGetInvalidAssert(t *testing.T) {
 func TestRequestsUnknownKey(t *testing.T) {
 	t.Parallel()
 
-	var req requests
+	var req *requests = NewRequests()
 
 	_, ok := req.get("unknown key")
-
-	assert.Check(t, !ok)
-}
-
-func TestRequestsInvalidTypeCast(t *testing.T) {
-	t.Parallel()
-
-	var req requests
-
-	req.store.Store("some_key", "invalid value")
-
-	_, ok := req.get("some_key")
 
 	assert.Check(t, !ok)
 }
@@ -46,10 +35,10 @@ func TestRequestsInvalidTypeCast(t *testing.T) {
 func TestRequestsReset(t *testing.T) {
 	t.Parallel()
 
-	var req requests
+	var req *requests = NewRequests()
 
 	req.prepare()
-	req.store.Store("some_key", "invalid value")
+	req.prepare()
 
 	assert.Equal(t, 2, req.len())
 
@@ -64,20 +53,16 @@ func TestRequestsReset(t *testing.T) {
 func TestLiveQueriesGetErrorCases(t *testing.T) {
 	t.Parallel()
 
-	var lq liveQueries
+	var lq *liveQueries = NewLiveQueries()
 
 	_, ok := lq.get("unknown_key", false)
-	assert.Check(t, !ok)
-
-	lq.store.Store("some_key", "invalid value")
-	_, ok = lq.get("some_key", false)
 	assert.Check(t, !ok)
 }
 
 func TestLiveQueriesDel(t *testing.T) {
 	t.Parallel()
 
-	var lq liveQueries
+	var lq *liveQueries = NewLiveQueries()
 
 	ch, ok := lq.get("some_key", true)
 	assert.Check(t, ok)
@@ -89,4 +74,120 @@ func TestLiveQueriesDel(t *testing.T) {
 	case <-time.After(1 * time.Second):
 		t.Fatal("channel not closed")
 	}
+}
+
+func TestNewRandBytes(t *testing.T) {
+	t.Parallel()
+	// Basic test to ensure that NewRandBytes doesn't panic.
+	_ = NewRandBytes()
+}
+
+func TestRandBytes_Read(t *testing.T) {
+	rb := NewRandBytes()
+
+	t.Run("Full Uint64s", func(t *testing.T) {
+		t.Parallel()
+
+		origBytes := make([]byte, 16)
+		b := make([]byte, len(origBytes))
+		copy(b, origBytes)
+
+		rb.Read(b)
+
+		assert.Check(t,
+			!bytes.Equal(b, origBytes),
+			"Bytes were not modified",
+		)
+	})
+
+	t.Run("Partial Uint64", func(t *testing.T) {
+		t.Parallel()
+
+		origBytes := make([]byte, 5)
+		b := make([]byte, len(origBytes))
+		copy(b, origBytes)
+
+		rb.Read(b)
+
+		assert.Check(t,
+			!bytes.Equal(b, origBytes),
+			"Bytes were not modified",
+		)
+	})
+
+	t.Run("Zero Length", func(t *testing.T) {
+		t.Parallel()
+
+		b := make([]byte, 0)
+
+		rb.Read(b) // Should not panic
+
+		assert.Check(t,
+			len(b) == 0,
+			"Length of bytes should be 0, but is %d", len(b),
+		)
+	})
+
+	t.Run("Multiple Reads", func(t *testing.T) {
+		t.Parallel()
+
+		numBytes := rand.Uint32N(256) + 1
+
+		bytes1 := make([]byte, numBytes)
+		bytes2 := make([]byte, numBytes)
+		rb.Read(bytes1)
+		rb.Read(bytes2)
+		// Check if the two byte slices are different.
+		// This doesn't guarantee randomness, but it does ensure the generator is advancing.
+		assert.Check(t,
+			!bytes.Equal(bytes1, bytes2),
+			"Multiple reads returned the same bytes",
+		)
+	})
+
+	t.Run("Large Read", func(t *testing.T) {
+		t.Parallel()
+
+		origBytes := make([]byte, 1024)
+		b := make([]byte, len(origBytes))
+		copy(b, origBytes)
+
+		rb.Read(b)
+
+		assert.Check(t,
+			!bytes.Equal(b, origBytes),
+			"Bytes were not modified",
+		)
+	})
+
+	t.Run("Concurrency", func(t *testing.T) {
+		t.Parallel()
+
+		const numGoRoutines = 24
+		done := make(chan bool)
+		for range numGoRoutines {
+			go func() {
+				origBytes := make([]byte, rand.Uint32N(256)+1)
+				origLen := len(origBytes)
+				origCap := cap(origBytes)
+
+				b := make([]byte, origLen)
+				copy(b, origBytes)
+
+				rb.Read(b)
+
+				assert.Equal(t, len(b), origLen)
+				assert.Equal(t, cap(b), origCap)
+				assert.Check(t,
+					!bytes.Equal(b, origBytes),
+					"Bytes were not modified",
+				)
+
+				done <- true
+			}()
+		}
+		for range numGoRoutines {
+			<-done
+		}
+	})
 }

--- a/stores_test.go
+++ b/stores_test.go
@@ -17,7 +17,7 @@ func TestStoresGetInvalidAssert(t *testing.T) {
 
 	pool.syncPool.Put("invalid type")
 
-	res := pool.Get()
+	res := pool.get()
 
 	assert.Check(t, res != nil)
 	assert.Check(t, bytes.Equal(res.Bytes(), []byte{}))
@@ -26,7 +26,7 @@ func TestStoresGetInvalidAssert(t *testing.T) {
 func TestRequestsUnknownKey(t *testing.T) {
 	t.Parallel()
 
-	var req *requests = NewRequests()
+	var req *requests = newRequests()
 
 	_, ok := req.get("unknown key")
 
@@ -36,7 +36,7 @@ func TestRequestsUnknownKey(t *testing.T) {
 func TestRequestsReset(t *testing.T) {
 	t.Parallel()
 
-	var req *requests = NewRequests()
+	var req *requests = newRequests()
 
 	req.prepare()
 	req.prepare()
@@ -54,7 +54,7 @@ func TestRequestsReset(t *testing.T) {
 func TestLiveQueriesGetErrorCases(t *testing.T) {
 	t.Parallel()
 
-	var lq *liveQueries = NewLiveQueries()
+	var lq *liveQueries = newLiveQueries()
 
 	_, ok := lq.get("unknown_key", false)
 	assert.Check(t, !ok)
@@ -63,7 +63,7 @@ func TestLiveQueriesGetErrorCases(t *testing.T) {
 func TestLiveQueriesDel(t *testing.T) {
 	t.Parallel()
 
-	var lq *liveQueries = NewLiveQueries()
+	var lq = newLiveQueries()
 
 	ch, ok := lq.get("some_key", true)
 	assert.Check(t, ok)
@@ -79,12 +79,12 @@ func TestLiveQueriesDel(t *testing.T) {
 
 func TestNewRandBytes(t *testing.T) {
 	t.Parallel()
-	// Basic test to ensure that NewRandBytes doesn't panic.
-	_ = NewRandBytes()
+	// Basic test to ensure that newRandBytes doesn't panic.
+	_ = newRandBytes()
 }
 
 func TestRandBytes_Read(t *testing.T) {
-	rb := NewRandBytes()
+	rb := newRandBytes()
 
 	t.Run("Full Uint64s", func(t *testing.T) {
 		t.Parallel()
@@ -93,7 +93,7 @@ func TestRandBytes_Read(t *testing.T) {
 		b := make([]byte, len(origBytes))
 		copy(b, origBytes)
 
-		rb.Read(b)
+		rb.read(b)
 
 		assert.Check(t,
 			!bytes.Equal(b, origBytes),
@@ -108,7 +108,7 @@ func TestRandBytes_Read(t *testing.T) {
 		b := make([]byte, len(origBytes))
 		copy(b, origBytes)
 
-		rb.Read(b)
+		rb.read(b)
 
 		assert.Check(t,
 			!bytes.Equal(b, origBytes),
@@ -121,7 +121,7 @@ func TestRandBytes_Read(t *testing.T) {
 
 		b := make([]byte, 0)
 
-		rb.Read(b) // Should not panic
+		rb.read(b) // Should not panic
 
 		assert.Check(t,
 			len(b) == 0,
@@ -136,8 +136,8 @@ func TestRandBytes_Read(t *testing.T) {
 
 		bytes1 := make([]byte, numBytes)
 		bytes2 := make([]byte, numBytes)
-		rb.Read(bytes1)
-		rb.Read(bytes2)
+		rb.read(bytes1)
+		rb.read(bytes2)
 		// Check if the two byte slices are different.
 		// This doesn't guarantee randomness, but it does ensure the generator is advancing.
 		assert.Check(t,
@@ -153,7 +153,7 @@ func TestRandBytes_Read(t *testing.T) {
 		b := make([]byte, len(origBytes))
 		copy(b, origBytes)
 
-		rb.Read(b)
+		rb.read(b)
 
 		assert.Check(t,
 			!bytes.Equal(b, origBytes),
@@ -178,7 +178,7 @@ func TestRandBytes_Read(t *testing.T) {
 				b := make([]byte, origLen)
 				copy(b, origBytes)
 
-				rb.Read(b)
+				rb.read(b)
 
 				assert.Equal(t, len(b), origLen)
 				assert.Equal(t, cap(b), origCap)
@@ -193,7 +193,7 @@ func TestRandBytes_Read(t *testing.T) {
 }
 
 func TestRandBytes_Base62Str(t *testing.T) {
-	rb := NewRandBytes()
+	rb := newRandBytes()
 
 	t.Run("Concurrency", func(t *testing.T) {
 		t.Parallel()
@@ -206,7 +206,7 @@ func TestRandBytes_Base62Str(t *testing.T) {
 				defer wg.Done()
 
 				strLen := int(rand.Int32N(256) + 1)
-				str := rb.Base62Str(strLen)
+				str := rb.base62Str(strLen)
 
 				assert.Equal(t, len(str), strLen)
 			}()

--- a/stores_test.go
+++ b/stores_test.go
@@ -13,7 +13,7 @@ func TestStoresGetInvalidAssert(t *testing.T) {
 
 	var pool bufPool
 
-	pool.Pool.Put("invalid type")
+	pool.syncPool.Put("invalid type")
 
 	res := pool.Get()
 

--- a/stores_test.go
+++ b/stores_test.go
@@ -191,3 +191,26 @@ func TestRandBytes_Read(t *testing.T) {
 		wg.Wait()
 	})
 }
+
+func TestRandBytes_Base62Str(t *testing.T) {
+	rb := NewRandBytes()
+
+	t.Run("Concurrency", func(t *testing.T) {
+		t.Parallel()
+
+		const numGoRoutines = 24
+		wg := sync.WaitGroup{}
+		for range numGoRoutines {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+
+				strLen := int(rand.Int32N(256) + 1)
+				str := rb.Base62Str(strLen)
+
+				assert.Equal(t, len(str), strLen)
+			}()
+		}
+		wg.Wait()
+	})
+}


### PR DESCRIPTION
Thank you for submitting this pull request! We appreciate you spending the time to work on these changes.

## Motivation

Explain the motivation behind this pull request and what problem it aims to solve.

## Changes Made

```
refactor: hide sync.Pool methods, preallocate buffer for small responses
refactor(stores): use standard maps, faster request keys generation
fix: potentially infinite concurrency test for RandBytes.Read
perf(stores): improve performance of request key generation
```

```
golangci changes:
- increased short varname slightly
- excepted i
- set allowed block size of nlreturn to 3
```

## Testing

Detail your testing strategy, including steps to verify the changes made in this pull request.
If you modified code, provide instructions on how you validated your changes.

## Related Issues

List any related issues or pull requests that are addressed or impacted by this pull request.
Please link them for easy reference.

## Checklist

- [ ] I have read the [Contributing Guidelines](https://github.com/go-surreal/sdbc/blob/main/CONTRIBUTING.md).
