### PR TITLE
feat: make cbor settings configurable

### DIFF
--- a/client.go
+++ b/client.go
@@ -104,9 +104,9 @@ func NewClient(ctx context.Context, conf Config, opts ...Option) (*Client, error
 		MaxNestedLevels:   conf.CborMaxNestedLevels,
 		MaxArrayElements:  conf.CborMaxArrayElements,
 		MaxMapPairs:       conf.CborMaxMapPairs,
-		DupMapKey:         cbor.DupMapKeyQuiet,            // let the database handle that
-		ExtraReturnErrors: cbor.ExtraDecErrorUnknownField, // prevents hidden errors
-		UTF8:              cbor.UTF8RejectInvalid,         // reject invalid UTF-8
+		DupMapKey:         cbor.DupMapKeyQuiet,    // let the database handle that
+		ExtraReturnErrors: cbor.ExtraDecErrorNone, // ignore missing fields (currently required)
+		UTF8:              cbor.UTF8RejectInvalid, // reject invalid UTF-8
 	}
 
 	encTags := cbor.NewTagSet()

--- a/client.go
+++ b/client.go
@@ -18,7 +18,7 @@ import (
 const (
 	CborMinNestedLevels = 4
 	CborMaxNestedLevels = 65535
-	
+
 	CborMinArrayElements = 16
 	CborMaxArrayElements = 2147483647
 

--- a/client.go
+++ b/client.go
@@ -76,23 +76,18 @@ type Config struct {
 	// It will automatically be created if it does not exist.
 	Database string
 
-	Cbor CborConfig
-}
-
-type CborConfig struct {
-
-	// MaxNestedLevels specifies the max nested levels allowed for any combination of CBOR array, maps, and tags.
-	// Default is 32 levels and it can be set to [4, 65535]. Note that higher maximum levels of nesting can
+	// CborMaxNestedLevels specifies the max nested levels allowed for any combination of CBOR array, maps, and tags.
+	// Default is 32 levels, minimum is 4, maximum is 65535. Note that higher maximum levels of nesting can
 	// require larger amounts of stack to deserialize. Don't increase this higher than you require.
-	MaxNestedLevels int
+	CborMaxNestedLevels int
 
-	// MaxArrayElements specifies the max number of elements for CBOR arrays.
-	// Default is 128*1024=131072 and it can be set to [16, 2147483647]
-	MaxArrayElements int
+	// CborMaxArrayElements specifies the max number of elements for CBOR arrays.
+	// Default is 128*1024=131072, minimum is 16, maximum is 2147483647.
+	CborMaxArrayElements int
 
-	// MaxMapPairs specifies the max number of key-value pairs for CBOR maps.
-	// Default is 128*1024=131072 and it can be set to [16, 2147483647]
-	MaxMapPairs int
+	// CborMaxMapPairs specifies the max number of key-value pairs for CBOR maps.
+	// Default is 128*1024=131072, minimum is 16, maximum is 2147483647.
+	CborMaxMapPairs int
 }
 
 // NewClient creates a new client and connects to
@@ -106,9 +101,12 @@ func NewClient(ctx context.Context, conf Config, opts ...Option) (*Client, error
 	encOpts := cbor.EncOptions{}
 
 	decOpts := cbor.DecOptions{
-		MaxNestedLevels:  conf.Cbor.MaxNestedLevels,
-		MaxArrayElements: conf.Cbor.MaxArrayElements,
-		MaxMapPairs:      conf.Cbor.MaxMapPairs,
+		MaxNestedLevels:   conf.CborMaxNestedLevels,
+		MaxArrayElements:  conf.CborMaxArrayElements,
+		MaxMapPairs:       conf.CborMaxMapPairs,
+		DupMapKey:         cbor.DupMapKeyQuiet,            // let the database handle that
+		ExtraReturnErrors: cbor.ExtraDecErrorUnknownField, // prevents hidden errors
+		UTF8:              cbor.UTF8RejectInvalid,         // reject invalid UTF-8
 	}
 
 	encTags := cbor.NewTagSet()

--- a/client.go
+++ b/client.go
@@ -16,6 +16,17 @@ import (
 )
 
 const (
+	CborMinNestedLevels = 4
+	CborMaxNestedLevels = 65535
+	
+	CborMinArrayElements = 16
+	CborMaxArrayElements = 2147483647
+
+	CborMinMapPairs = 16
+	CborMaxMapPairs = 2147483647
+)
+
+const (
 	schemeWS  = "ws"
 	schemeWSS = "wss"
 

--- a/methods_test.go
+++ b/methods_test.go
@@ -576,21 +576,17 @@ func TestLiveFilter(t *testing.T) {
 	// Prioritize checking the error channel (liveErrChan) to handle any errors
 	// before processing results from the response channel (liveResChan).
 	select {
-
 	case liveErr := <-liveErrChan:
 		if liveErr != nil {
 			t.Fatal(liveErr)
 		}
-
 	case <-time.After(1 * time.Second):
 		t.Fatal("timeout")
 	}
 
 	select {
-
 	case liveRes := <-liveResChan:
 		assert.Check(t, cmp.DeepEqual(modelCreate, *liveRes, cmpopts.IgnoreUnexported(ID{})))
-
 	case <-time.After(1 * time.Second):
 		t.Fatal("timeout")
 	}

--- a/methods_test.go
+++ b/methods_test.go
@@ -855,10 +855,9 @@ type baseResponse[T any] struct {
 }
 
 type liveResponse[T any] struct {
-	ID     []byte   `cbor:"id"`
-	Record []string `cbor:"record"`
-	Action string   `cbor:"action"`
-	Result T        `cbor:"result"`
+	ID     []byte `cbor:"id"`
+	Action string `cbor:"action"`
+	Result T      `cbor:"result"`
 }
 
 type someModel struct {

--- a/methods_test.go
+++ b/methods_test.go
@@ -573,6 +573,8 @@ func TestLiveFilter(t *testing.T) {
 	assert.Check(t, cmp.Equal(modelIn.Value, modelCreate.Value))
 	assert.Check(t, cmp.DeepEqual(modelIn.Slice, modelCreate.Slice))
 
+	// Prioritize checking the error channel (liveErrChan) to handle any errors
+	// before processing results from the response channel (liveResChan).
 	select {
 
 	case liveErr := <-liveErrChan:

--- a/types.go
+++ b/types.go
@@ -399,7 +399,10 @@ type responseError struct {
 }
 
 type liveQueryID struct {
-	ID []byte `json:"id"`
+	ID     []byte          `json:"id"`
+	Action string          `json:"action"`
+	Record []string        `json:"record"`
+	Result cbor.RawMessage `json:"result"`
 }
 
 //

--- a/types.go
+++ b/types.go
@@ -399,10 +399,7 @@ type responseError struct {
 }
 
 type liveQueryID struct {
-	ID     []byte          `json:"id"`
-	Action string          `json:"action"`
-	Record []string        `json:"record"`
-	Result cbor.RawMessage `json:"result"`
+	ID []byte `json:"id"`
 }
 
 //


### PR DESCRIPTION
## Motivation

Currently the default settings for the underlying cbor package are used. This makes it impossible to configure settings like MaxArrayElements, but there are scenarios where increasing those values is required.

## Changes Made

Introduce cbor settings to the client config.

- [x] I have read the [Contributing Guidelines](https://github.com/go-surreal/sdbc/blob/main/CONTRIBUTING.md).
